### PR TITLE
[DRAFT] Bump libcramjam to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ blosc2-shared = ["libcramjam/blosc2-shared"]
 [dependencies]
 clap = { version = "^4.2", features = ["derive"] }
 bytesize = "^1"
-libcramjam = { version = "0.4.2" }
+libcramjam = { version = "0.6.0" }
 
 [profile.release]
 strip = true


### PR DESCRIPTION
Just adjusting the dependency bound to build with the latest release.